### PR TITLE
Fix TypeError: filteredNotices.map is not a function by ensuring it's an array before mapping

### DIFF
--- a/src/components/main/Notices.tsx
+++ b/src/components/main/Notices.tsx
@@ -371,7 +371,7 @@ function Notices() {
                     </div>
                 </div>
                 <div>
-                    {filteredNotices ? (
+                    {Array.isArray(filteredNotices) ? (
                         <div className="grid grid-cols-4 gap-2">
                             {filteredNotices.map((notice) => (
                                 <div key={notice.id}>


### PR DESCRIPTION
This update fixes the TypeError: filteredNotices.map is not a function error by ensuring that filteredNotices is always an array before attempting to call .map().